### PR TITLE
finished styling. matches wireframe

### DIFF
--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -46,48 +46,53 @@ export const Register = (props) => {
 
     //function to update user (except checkbox)
     const updateUser = (evt) => {
-        const copy = {...user}
+        const copy = { ...user }
         copy[evt.target.id] = evt.target.value
         setUser(copy)
     }
 
     return (
         <main className="general-font">
-            <form onSubmit={handleRegister}>
-                <h2 className="fs-1 text custom-text-green-withoutHover general-font">TS</h2>
-                <h1>Registration Form</h1>
-                <fieldset>
-                    <label htmlFor="username">Username:</label>
-                    <input onChange={updateUser}
-                        type="text" id="username"
-                        placeholder="Enter username"
-                        required
-                        autoFocus />
-                </fieldset>
-                <fieldset>
-                    <label htmlFor="password">Password:</label>
-                    <input onChange={updateUser}
-                        type="password" id="password"
-                        placeholder="Password" required />
-                </fieldset>
-                <fieldset>
-                    <label htmlFor="email"> Email: </label>
-                    <input onChange={updateUser}
-                        type="email" id="email"
-                        placeholder="Email address"
-                        required />
-                </fieldset>
-                <fieldset>
-                    <label htmlFor="isAdmin">
-                        <input onChange={(event) => {
-                            const copy = {...user}
-                            copy.isAdmin = event.target.checked
-                            setUser(copy)
-                        }}
-                        type="checkbox" id="isAdmin" />
-                        I am an admin
-                    </label>
-                </fieldset>
+            <h2 className="fs-1 text custom-text-green-withoutHover general-font">TS</h2>
+            <form className="registration-form" onSubmit={handleRegister}>
+                <h1 className="registration-form-title">Registration Form</h1>
+                <div className="registration-form-fields">
+                    <fieldset className="registration-form-labelAndInput">
+                        <label htmlFor="username">Username</label>
+                        <input className="registration-form-field"
+                            onChange={updateUser}
+                            type="text" id="username"
+                            placeholder="Enter username"
+                            required
+                            autoFocus />
+                    </fieldset>
+                    <fieldset className="registration-form-labelAndInput">
+                        <label htmlFor="password">Password</label>
+                        <input className="registration-form-field"
+                            onChange={updateUser}
+                            type="password" id="password"
+                            placeholder="Password" required />
+                    </fieldset>
+                    <fieldset className="registration-form-labelAndInput">
+                        <label htmlFor="email"> Email </label>
+                        <input className="registration-form-field"
+                            onChange={updateUser}
+                            type="email" id="email"
+                            placeholder="Email address"
+                            required />
+                    </fieldset>
+                    <fieldset className="registration-form-labelAndInput">
+                        <label htmlFor="isAdmin">
+                            <input onChange={(event) => {
+                                const copy = { ...user }
+                                copy.isAdmin = event.target.checked
+                                setUser(copy)
+                            }}
+                                type="checkbox" id="isAdmin" />
+                            I am an admin
+                        </label>
+                    </fieldset>
+                </div>
                 <fieldset>
                     <button className="btn btn-secondary" type="submit">
                         Register

--- a/src/index.css
+++ b/src/index.css
@@ -91,8 +91,6 @@ code {
   margin: 1rem;
 }
 
-
-
 .login-form-link {
   font-size: small;
   margin-left: 2rem;
@@ -108,16 +106,35 @@ code {
   margin-top: 3rem;
 }
 
+.registration-form {
+  width: 30rem;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 6rem;
+}
+
+.registration-form-title{
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.registration-form-field{
+  width: 100%;
+}
+
+.registration-form-labelAndInput{
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+}
+
 /* Home Page */
 
 .homepage-content{
-  /* border: 5px solid red; */
   margin-top: 4rem;
   margin-left: 4rem;
   height: 25rem;
 }
 
 .homepage-category{
-  /* border: 5px dotted red; */
   height: 21rem;
 }


### PR DESCRIPTION
I styled the registration page to match the wireframe. This brings a more cohesive look to the project. New users are  introduced to consistent styling at the beginning of their experience with the website.

I used several custom CSS classes to achieve the styling.

Wireframe:
![TheStudy RegistrationForm Wireframe](https://user-images.githubusercontent.com/115668909/235718144-549123dc-eb49-4225-a548-3741db91eea4.png)

Actual:
![TheStudy RegistrationForm Actual](https://user-images.githubusercontent.com/115668909/235718329-c92d0608-7acc-42e2-a803-73628358ef51.png)
