### PR TITLE
Styling/my uploads page

### DIFF
--- a/src/components/uploads/Homepage.js
+++ b/src/components/uploads/Homepage.js
@@ -17,7 +17,7 @@ export const Homepage = () => {
     )
 
     return (
-        <main className="general-font homepage-content">
+        <main className="general-font page-content">
             <h1>Research Categories</h1>
             <div className=" homepage-category d-flex flex-column justify-content-between">
             {categories.map((category) => {

--- a/src/components/uploads/MyUploads.js
+++ b/src/components/uploads/MyUploads.js
@@ -23,9 +23,9 @@ export const MyUploads = () => {
 
 
     return (
-        <main className="general-font">
+        <main className="general-font page-content">
             <h1>My Uploads</h1>
-            <article>
+            <article className="d-flex justify-content-between flex-wrap">
                 {
                     resources.length === 0? <p>Your uploads will appear here. Submit new learning resources to see this page filled!</p> :
                     resources.map((resource) => <Resource

--- a/src/components/uploads/Resource.js
+++ b/src/components/uploads/Resource.js
@@ -31,7 +31,7 @@ export const Resource = ({ id, link, creator, title, img, format, description, g
 
     return (
         <div >
-            <section className="card bg-secondary mb-3 resource" style={{ width: "20rem", height: "22rem" }}>
+            <section className="card bg-secondary mb-3 resource" style={{ width: "20rem", maxHeight: "22rem", height: "auto" }}>
                 <div className="d-flex justify-content-between">
                     <div className="btn btn-dark card-title d-flex align-items-center" style={{height: "6rem", width: "auto"}}>
                         <a className="custom-text-green-withoutHover" href={link}>{title}</a>
@@ -42,7 +42,7 @@ export const Resource = ({ id, link, creator, title, img, format, description, g
                     {format} Description
                 </button>
                 <div className="collapse show" id={`collapse${id}`} ref={collapsibleElement}>
-                    <div className="card-text">
+                    <div className="card-text small">
                         {description}
                     </div>
                 </div>

--- a/src/components/uploads/Resource.js
+++ b/src/components/uploads/Resource.js
@@ -31,19 +31,21 @@ export const Resource = ({ id, link, creator, title, img, format, description, g
 
     return (
         <div >
-            <section className="card bg-secondary mb-3 resource" style={{ width: "20rem", height: "23rem" }}>
-                <div className="btn btn-dark card-title">
-                    <a className="custom-text-green-withoutHover" href={link}>{title}</a>
+            <section className="card bg-secondary mb-3 resource" style={{ width: "20rem", height: "21.85rem" }}>
+                <div className="d-flex justify-content-between">
+                    <div className="btn btn-dark card-title d-flex align-items-center" style={{height: "5rem"}}>
+                        <a className="custom-text-green-withoutHover" href={link}>{title}</a>
+                    </div>
+                    <img src={img} className="card-img" style={{ width: "5rem", height: "auto", objectFit: "scale-down" }} />
                 </div>
-                <img src={img} className="card-img" style={{ width: "auto", height: "4rem", objectFit: "cover" }} />
                 <button type="button" className="btn btn-dark" data-bs-toggle="collapse" data-bs-target={`#collapse${id}`}>
                     {format} Description
                 </button>
-                    <div className="collapse show" id={`collapse${id}`} ref={collapsibleElement}>
-                        <div className="card-text">
-                            {description}
-                        </div>
+                <div className="collapse show" id={`collapse${id}`} ref={collapsibleElement}>
+                    <div className="card-text">
+                        {description}
                     </div>
+                </div>
                 <div className="card-body">
                 </div>
                 {

--- a/src/components/uploads/Resource.js
+++ b/src/components/uploads/Resource.js
@@ -31,12 +31,12 @@ export const Resource = ({ id, link, creator, title, img, format, description, g
 
     return (
         <div >
-            <section className="card bg-secondary mb-3 resource" style={{ width: "20rem", height: "21.85rem" }}>
+            <section className="card bg-secondary mb-3 resource" style={{ width: "20rem", height: "22rem" }}>
                 <div className="d-flex justify-content-between">
-                    <div className="btn btn-dark card-title d-flex align-items-center" style={{height: "5rem"}}>
+                    <div className="btn btn-dark card-title d-flex align-items-center" style={{height: "6rem", width: "auto"}}>
                         <a className="custom-text-green-withoutHover" href={link}>{title}</a>
                     </div>
-                    <img src={img} className="card-img" style={{ width: "5rem", height: "auto", objectFit: "scale-down" }} />
+                    <img src={img} className="card-img" style={{ maxWidth: "9rem", width: "auto", maxHeight: "6rem", objectFit: "scale-down" }} />
                 </div>
                 <button type="button" className="btn btn-dark" data-bs-toggle="collapse" data-bs-target={`#collapse${id}`}>
                     {format} Description

--- a/src/index.css
+++ b/src/index.css
@@ -42,7 +42,9 @@ code {
 
 .resource {
   width: 18rem;
-  margin: 4rem;
+  margin-left: 0rem;
+  margin-right: 4rem;
+  margin-top: 4rem;
   padding: 1rem;
 }
 
@@ -51,6 +53,12 @@ code {
   margin-top: 0.25rem;
   margin-bottom: 0.25rem;
   padding: 0.5rem;
+}
+
+.page-content{
+  margin-top: 4rem;
+  margin-left: 4rem;
+  height: 25rem;
 }
 
 /* Login and registration pages */
@@ -142,12 +150,8 @@ code {
 
 /* Home Page */
 
-.homepage-content{
-  margin-top: 4rem;
-  margin-left: 4rem;
-  height: 25rem;
-}
-
 .homepage-category{
   height: 21rem;
 }
+
+/* My Uploads Page*/


### PR DESCRIPTION

I used a combination of Bootstrap and custom CSS classes to style the title and contents of the My Uploads. This includes resource cards for each book, video, etc. I did so to organize the page and maintain the website theme. I testing various size images and the longest description possible. I also tested the resource cards by viewing their arrangement on other pages. The cards and arrangement remained consistent. 

I changed some details of the styling from the wireframe to the actual website.

Wireframe:
![TheStudy MyUploads Wireframe](https://user-images.githubusercontent.com/115668909/235968630-67af22e3-42cc-4838-a36f-7bad5462a85f.png)



Actual: 
![TheStudy MyUploads Actual](https://user-images.githubusercontent.com/115668909/235968680-7f148a21-0f7b-4898-8545-769de1a90914.png)
