### PR TITLE
minor change to make render smoother

### DIFF
--- a/src/components/uploads/CategoryResources.js
+++ b/src/components/uploads/CategoryResources.js
@@ -4,7 +4,7 @@ import { Resource } from "./Resource"
 
 export const CategoryResources = () => {
     const { categoryId } = useParams()
-    const [resources, updateResources] = useState([])
+    const [resources, updateResources] = useState(["fakedata"])
     const [category, setCategory] = useState({
         id: 0,
         type: "",

--- a/src/components/uploads/MyUploads.js
+++ b/src/components/uploads/MyUploads.js
@@ -4,7 +4,7 @@ import { Resource } from "./Resource"
 export const MyUploads = () => {
     const localStudyUser = localStorage.getItem("study_user")
     const studyUserObject = JSON.parse(localStudyUser)
-    const [resources, updateResources] = useState([])
+    const [resources, updateResources] = useState(["fakedata"])
 
     const getMyResources = () => {
         fetch(`http://localhost:8088/resources?_expand=format&creatorId=${studyUserObject.id}`)


### PR DESCRIPTION
## What?
Changed initial state of "resources" variable so that it is not empty. This prevents the triggering of a ternary statement. 
## Why?
Previous behavior was a "jerkier" experience during render. 
## How?
Set initial state of "resources" to be filled with a value that is quickly replaced by real data. The ternary statement previously mentioned is only triggered if the value is an empty array.