### PR TITLE
styling reflects wireframe

### DIFF
--- a/src/components/forms/EditForm.js
+++ b/src/components/forms/EditForm.js
@@ -90,7 +90,7 @@ export const EditForm = () => {
     }
 
     return (
-        <main className="general-font">
+        <main className="general-font  formPage d-flex flex-column align-items-center">
             <h1>Resource Edit Form</h1>
             <ResourceForm
                 submission={submission}

--- a/src/components/forms/ResourceForm.js
+++ b/src/components/forms/ResourceForm.js
@@ -4,8 +4,8 @@ export const ResourceForm = ({submission, handleSubmission, updateSubmissionNumb
 
 
     return (
-        <form onSubmit={handleSubmission}>
-            <fieldset>
+        <form className="formPage-content d-flex flex-column" onSubmit={handleSubmission}>
+            <fieldset className="formField d-flex flex-column">
                 <label htmlFor="formatId">Format</label>
                 <select
                     value={submission.formatId}
@@ -21,7 +21,7 @@ export const ResourceForm = ({submission, handleSubmission, updateSubmissionNumb
                     )}
                 </select>
             </fieldset>
-            <fieldset>
+            <fieldset className="formField d-flex flex-column">
                 <label htmlFor="categoryId">Category</label>
                 <select
                     value={submission.categoryId}
@@ -37,7 +37,7 @@ export const ResourceForm = ({submission, handleSubmission, updateSubmissionNumb
                     )}
                 </select>
             </fieldset>
-            <fieldset>
+            <fieldset className="formField d-flex flex-column">
                 <label htmlFor="title">Title</label>
                 <input
                     defaultValue={submission.title}
@@ -47,7 +47,7 @@ export const ResourceForm = ({submission, handleSubmission, updateSubmissionNumb
                     placeholder="Enter a title"
                     required />
             </fieldset>
-            <fieldset>
+            <fieldset className="formField d-flex flex-column">
                 <label htmlFor="url">URL</label>
                 <input
                     defaultValue={submission.url}
@@ -57,7 +57,7 @@ export const ResourceForm = ({submission, handleSubmission, updateSubmissionNumb
                     placeholder="https://www.url.com"
                     required />
             </fieldset>
-            <fieldset>
+            <fieldset className="formField d-flex flex-column">
                 <label htmlFor="image">Image URL</label>
                 <input
                     defaultValue={submission.image}
@@ -67,19 +67,19 @@ export const ResourceForm = ({submission, handleSubmission, updateSubmissionNumb
                     placeholder="www.image.com"
                     required />
             </fieldset>
-            <fieldset>
+            <fieldset className="formField d-flex flex-column">
                 <label htmlFor="description">Description</label>
                 <textarea
                     defaultValue={submission.description}
                     onChange={updateSubmission}
-                    id="description" rows="3" cols="35"
+                    id="description" rows="2" cols="50"
                     placeholder="Type a brief description of your resource"
                     style={{ resize: 'none' }}
                     required
-                    maxLength="105"></textarea>
+                    maxLength="100"></textarea>
             </fieldset>
             <fieldset>
-                <button className="btn btn-secondary" type="submit">
+                <button className="btn btn-secondary form-button" type="submit">
                     Submit
                 </button>
             </fieldset>

--- a/src/components/forms/SubmissionForm.js
+++ b/src/components/forms/SubmissionForm.js
@@ -75,7 +75,7 @@ export const SubmissionForm = () => {
     }
 
     return (
-        <main className="general-font">
+        <main className="general-font formPage d-flex flex-column align-items-center">
             <h1>Upload Submission Form</h1>
             <ResourceForm 
                 submission={submission}

--- a/src/index.css
+++ b/src/index.css
@@ -56,7 +56,7 @@ code {
 }
 
 .page-content{
-  margin-top: 4rem;
+  margin-top: 3.5rem;
   margin-left: 4rem;
   height: 25rem;
 }
@@ -154,4 +154,21 @@ code {
   height: 21rem;
 }
 
-/* My Uploads Page*/
+/*Upload and Edit Forms*/
+
+.formPage{
+  margin-top: 3.5rem;
+}
+
+.formPage-content{
+  min-width: 40%;
+  max-width: 60%
+}
+
+.formField{
+  margin: 0.2rem;
+}
+
+.form-button{
+  margin-left: 0.2rem;
+}


### PR DESCRIPTION
## What?
I changed the resource upload and edit forms to match the wireframe design.
## Why?
I did this to maintain a consistent theme across the website.
## How?
I used a combination of Bootstrap and custom CSS classes.
## Testing?
I tested the forms as a just-in-case (JIC) and received no errors. Everything continues to function as expected.
## Screenshots (optional)
Submission form wireframe:
![TheStudy SubmissionForm Wireframe](https://user-images.githubusercontent.com/115668909/236264164-3a84f99e-443a-487c-a178-2e663bc45b9a.png)

Submission form actual:
![TheStudy SubmissionForm Actual](https://user-images.githubusercontent.com/115668909/236264212-36d750e6-a6b5-4a47-9cf3-ca134127a805.png)
