### PR TITLE
bug fixed

### DIFF
--- a/src/components/uploads/Homepage.js
+++ b/src/components/uploads/Homepage.js
@@ -54,7 +54,7 @@ export const Homepage = () => {
     )
 
     const getAllResources = () => {
-        fetch('http://localhost:8088/resources')
+        fetch('http://localhost:8088/resources?_expand=format')
             .then(res => res.json())
             .then((resources) => {
                 setResources(resources)


### PR DESCRIPTION
## What?
Resource cards on the homepage were not displaying their format properly. I corrected this.
## Why?
This makes the format obvious to the user. When they search by format, being able to confirm the search results puts the user at ease.
## How?
I realized the module was accessing a list of resources. It needed to access a list of resources WITH the attached format objects. I altered the original fetch that sets the resources list to include the format objects.
## Testing?
Double checked several resource cards from the database with their display.
## Screenshots (optional)
Successful display:
![TheStudy Homepage AllUploads BugCorrected](https://github.com/conorgetty19/nss-capstone1-The-Study/assets/115668909/e1aee566-cfb6-4d85-9b63-09dbbcc1686b)
